### PR TITLE
泛域名创建证书时自动添加主域名

### DIFF
--- a/src/apisix.js
+++ b/src/apisix.js
@@ -149,7 +149,7 @@ async function removeVerifyRoute(domain) {
 }
 
 /**
- * 列出指定单sni的证书，不传列出所有单sni的证书
+ * 列出指定单sni的证书，不传列出所有单sni的证书(泛域名也包括在内)
  * @typedef {{id: string, domain: string, validity_start: number, validity_end: number}} Item
  * @param {string|undefined} sni
  * @returns {Promise<Array<Item>>}
@@ -165,14 +165,14 @@ async function listSSL(sni) {
   }
 
   const results = []
-
   list.forEach(item => {
-    if (item.snis.length > 1) return
-    if (sni && sni !== item.snis[0]) return
-
+    var domain = item.snis.find(sni => sni.startsWith("*."));
+    if (!domain && item.snis.length > 1) return
+    domain = domain || item.snis[0];
+    if (sni && domain.indexOf(sni) < 0) return
     results.push({
       id: item.id,
-      domain: item.snis[0],
+      domain: domain,
       validity_start: item.validity_start,
       validity_end: item.validity_end
     })

--- a/src/task.js
+++ b/src/task.js
@@ -87,7 +87,12 @@ async function doTask() {
     const mail = task.mail || config.acme_mail
     const serviceList = task.serviceList
 
-    const dnsParam = config.dns_api.find(item => item.domain == common.getRootDomain(domain))
+    let anyParsm = config.dns_api.find(item => item.domain == "*")
+    let dnsParam = config.dns_api.find(item => item.domain == common.getRootDomain(domain))
+    if (!dnsParam && anyParsm){
+      // 使用 * 匹配参数（只需要配置dns解析服务商即可）
+      dnsParam = anyParsm;
+    }
 
     let isAddRoute = false
     try {


### PR DESCRIPTION
例如  *.demo.com 创建时
提交参数为  -d demo.com  -d *.demo.com 

配置参数 dns_api 支持设置  *  提供通用匹配，只用一个dns服务器时，添加域名只需要修改dns解析，不用改配置文件